### PR TITLE
1.16.1

### DIFF
--- a/internal/sandwich.go
+++ b/internal/sandwich.go
@@ -33,7 +33,7 @@ import (
 )
 
 // VERSION follows semantic versioning.
-const VERSION = "1.16"
+const VERSION = "1.16.1"
 
 const (
 	PermissionsDefault = 0o744

--- a/internal/shard.go
+++ b/internal/shard.go
@@ -442,7 +442,9 @@ func (sh *Shard) Heartbeat(ctx context.Context) {
 					)
 				}
 
-				sh.ErrorCh <- err
+				if err != nil {
+					sh.ErrorCh <- err
+				}
 
 				return
 			}


### PR DESCRIPTION
Fixes error channel being populated with a nil error, causing a segmentation fault.